### PR TITLE
답변 수정/삭제 기능 추가

### DIFF
--- a/src/main/java/forward/javaqna/domain/answer/command/AnswerCommandService.java
+++ b/src/main/java/forward/javaqna/domain/answer/command/AnswerCommandService.java
@@ -20,11 +20,11 @@ public class AnswerCommandService {
     private final MemberRepository memberRepository;
     private final QuestionRepository questionRepository;
 
-    public int createAnswer(String username, AnswerCreateRequest answerCreateRequest) {
+    public Integer createAnswer(String username, Integer questionId, AnswerCreateRequest answerCreateRequest) {
         Member member = memberRepository.findById(username)
                 .orElseThrow(() -> new IllegalArgumentException("회원 없음"));
 
-        Question question = questionRepository.findById(answerCreateRequest.getQuestionId())
+        Question question = questionRepository.findById(questionId)
                 .orElseThrow(() -> new IllegalArgumentException("질문 없음"));
 
         Answer answer = answerCreateRequest.toEntity(member, question);

--- a/src/main/java/forward/javaqna/domain/answer/command/AnswerCommandService.java
+++ b/src/main/java/forward/javaqna/domain/answer/command/AnswerCommandService.java
@@ -3,6 +3,7 @@ package forward.javaqna.domain.answer.command;
 import forward.javaqna.domain.answer.command.dto.AnswerRequestDto;
 import forward.javaqna.domain.answer.core.Answer;
 import forward.javaqna.domain.answer.core.AnswerRepository;
+import forward.javaqna.domain.answer.core.policy.AnswerPolicy;
 import forward.javaqna.domain.member.core.Member;
 import forward.javaqna.domain.member.core.MemberRepository;
 import forward.javaqna.domain.question.core.Question;
@@ -34,7 +35,7 @@ public class AnswerCommandService {
     public void modifyAnswer(String username, Integer answerId, AnswerRequestDto answerRequestDto) {
         Member member = getMember(username);
         Answer answer = getAnswer(answerId);
-        validAnswerHasMember(answer, member);
+        AnswerPolicy.checkAuthor(answer, member);
 
         String newContent = answerRequestDto.getContent();
         answer.edit(newContent);
@@ -43,7 +44,7 @@ public class AnswerCommandService {
     public void deleteAnswer(String username, Integer answerId) {
         Member member = getMember(username);
         Answer answer = getAnswer(answerId);
-        validAnswerHasMember(answer, member);
+        AnswerPolicy.checkAuthor(answer, member);
 
         answerRepository.delete(answer);
     }
@@ -61,9 +62,5 @@ public class AnswerCommandService {
     private Answer getAnswer(Integer answerId) {
         return answerRepository.findById(answerId)
                 .orElseThrow(() -> new EntityNotFoundException("답변이 존재하지 않습니다."));
-    }
-
-    private static void validAnswerHasMember(Answer answer, Member member) {
-        if (answer.getMember() != member) throw new IllegalStateException("작성자가 아니므로 수정/삭제 할 수 없습니다.");
     }
 }

--- a/src/main/java/forward/javaqna/domain/answer/command/AnswerCommandService.java
+++ b/src/main/java/forward/javaqna/domain/answer/command/AnswerCommandService.java
@@ -1,12 +1,13 @@
 package forward.javaqna.domain.answer.command;
 
-import forward.javaqna.domain.answer.command.dto.AnswerCreateRequest;
+import forward.javaqna.domain.answer.command.dto.AnswerRequestDto;
 import forward.javaqna.domain.answer.core.Answer;
 import forward.javaqna.domain.answer.core.AnswerRepository;
 import forward.javaqna.domain.member.core.Member;
 import forward.javaqna.domain.member.core.MemberRepository;
 import forward.javaqna.domain.question.core.Question;
 import forward.javaqna.domain.question.core.QuestionRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,16 +21,37 @@ public class AnswerCommandService {
     private final MemberRepository memberRepository;
     private final QuestionRepository questionRepository;
 
-    public Integer createAnswer(String username, Integer questionId, AnswerCreateRequest answerCreateRequest) {
-        Member member = memberRepository.findById(username)
-                .orElseThrow(() -> new IllegalArgumentException("회원 없음"));
+    public Integer createAnswer(String username, Integer questionId, AnswerRequestDto answerRequestDto) {
+        Member member = getMember(username);
+        Question question = getQuestion(questionId);
 
-        Question question = questionRepository.findById(questionId)
-                .orElseThrow(() -> new IllegalArgumentException("질문 없음"));
-
-        Answer answer = answerCreateRequest.toEntity(member, question);
+        Answer answer = answerRequestDto.toEntity(member, question);
         answerRepository.save(answer);
 
         return answer.getId();
+    }
+
+    public void modifyAnswer(String username, Integer answerId, AnswerRequestDto answerRequestDto) {
+        Member member = getMember(username);
+        Answer answer = getAnswer(answerId);
+        if (answer.getMember() != member) throw new IllegalStateException("작성자가 아니므로 수정할 수 없습니다.");
+
+        String newContent = answerRequestDto.getContent();
+        answer.edit(newContent);
+    }
+
+    private Question getQuestion(Integer questionId) {
+        return questionRepository.findById(questionId)
+                .orElseThrow(() -> new EntityNotFoundException("질문이 존재하지 않습니다."));
+    }
+
+    private Member getMember(String username) {
+        return memberRepository.findById(username)
+                .orElseThrow(() -> new EntityNotFoundException("회원이 존재하지 않습니다."));
+    }
+
+    private Answer getAnswer(Integer answerId) {
+        return answerRepository.findById(answerId)
+                .orElseThrow(() -> new EntityNotFoundException("답변이 존재하지 않습니다."));
     }
 }

--- a/src/main/java/forward/javaqna/domain/answer/command/AnswerCommandService.java
+++ b/src/main/java/forward/javaqna/domain/answer/command/AnswerCommandService.java
@@ -34,10 +34,18 @@ public class AnswerCommandService {
     public void modifyAnswer(String username, Integer answerId, AnswerRequestDto answerRequestDto) {
         Member member = getMember(username);
         Answer answer = getAnswer(answerId);
-        if (answer.getMember() != member) throw new IllegalStateException("작성자가 아니므로 수정할 수 없습니다.");
+        validAnswerHasMember(answer, member);
 
         String newContent = answerRequestDto.getContent();
         answer.edit(newContent);
+    }
+
+    public void deleteAnswer(String username, Integer answerId) {
+        Member member = getMember(username);
+        Answer answer = getAnswer(answerId);
+        validAnswerHasMember(answer, member);
+
+        answerRepository.delete(answer);
     }
 
     private Question getQuestion(Integer questionId) {
@@ -53,5 +61,9 @@ public class AnswerCommandService {
     private Answer getAnswer(Integer answerId) {
         return answerRepository.findById(answerId)
                 .orElseThrow(() -> new EntityNotFoundException("답변이 존재하지 않습니다."));
+    }
+
+    private static void validAnswerHasMember(Answer answer, Member member) {
+        if (answer.getMember() != member) throw new IllegalStateException("작성자가 아니므로 수정/삭제 할 수 없습니다.");
     }
 }

--- a/src/main/java/forward/javaqna/domain/answer/command/dto/AnswerCreateRequest.java
+++ b/src/main/java/forward/javaqna/domain/answer/command/dto/AnswerCreateRequest.java
@@ -9,7 +9,6 @@ import lombok.Data;
 public class AnswerCreateRequest {
 
     private String content;
-    private int questionId;
 
     public Answer toEntity(Member member, Question question) {
         return question.addAnswer(content, member);

--- a/src/main/java/forward/javaqna/domain/answer/command/dto/AnswerRequestDto.java
+++ b/src/main/java/forward/javaqna/domain/answer/command/dto/AnswerRequestDto.java
@@ -6,7 +6,7 @@ import forward.javaqna.domain.question.core.Question;
 import lombok.Data;
 
 @Data
-public class AnswerCreateRequest {
+public class AnswerRequestDto {
 
     private String content;
 

--- a/src/main/java/forward/javaqna/domain/answer/core/Answer.java
+++ b/src/main/java/forward/javaqna/domain/answer/core/Answer.java
@@ -11,6 +11,7 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 @Entity
 @NoArgsConstructor
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 public class Answer extends BaseEntity {

--- a/src/main/java/forward/javaqna/domain/answer/core/Answer.java
+++ b/src/main/java/forward/javaqna/domain/answer/core/Answer.java
@@ -30,4 +30,8 @@ public class Answer extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    public void edit(String newContent) {
+        this.content = newContent;
+    }
 }

--- a/src/main/java/forward/javaqna/domain/answer/core/policy/AnswerPolicy.java
+++ b/src/main/java/forward/javaqna/domain/answer/core/policy/AnswerPolicy.java
@@ -1,0 +1,11 @@
+package forward.javaqna.domain.answer.core.policy;
+
+import forward.javaqna.domain.answer.core.Answer;
+import forward.javaqna.domain.member.core.Member;
+
+public class AnswerPolicy {
+
+    public static void checkAuthor(Answer answer, Member member) {
+        if (answer.getMember() != member) throw new IllegalStateException("작성자가 아니므로 수정/삭제 할 수 없습니다.");
+    }
+}

--- a/src/main/java/forward/javaqna/domain/question/core/Question.java
+++ b/src/main/java/forward/javaqna/domain/question/core/Question.java
@@ -35,7 +35,6 @@ public class Question extends BaseEntity {
     private Member member;
 
     @OneToMany(mappedBy = "question", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
-    @Builder.Default
     private List<Answer> answerList = new ArrayList<>();
 
     public Answer addAnswer(String content, Member member) {

--- a/src/test/java/forward/javaqna/domain/answer/command/AnswerCommandServiceTest.java
+++ b/src/test/java/forward/javaqna/domain/answer/command/AnswerCommandServiceTest.java
@@ -1,6 +1,6 @@
 package forward.javaqna.domain.answer.command;
 
-import forward.javaqna.domain.answer.command.dto.AnswerCreateRequest;
+import forward.javaqna.domain.answer.command.dto.AnswerRequestDto;
 import forward.javaqna.domain.answer.core.Answer;
 import forward.javaqna.domain.answer.core.AnswerRepository;
 import forward.javaqna.domain.member.core.Member;
@@ -16,6 +16,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @Transactional
@@ -45,7 +46,7 @@ class AnswerCommandServiceTest {
     void t1() {
 
         // given
-        AnswerCreateRequest request = new AnswerCreateRequest();
+        AnswerRequestDto request = new AnswerRequestDto();
         request.setContent("테스트 답변입니다.");
 
         // when
@@ -62,5 +63,53 @@ class AnswerCommandServiceTest {
         // 양방향 매핑 확인
         Question findQuestion = questionRepository.findById(question1.getId()).get();
         assertThat(findQuestion.getAnswerList()).contains(savedAnswer);
+    }
+
+    @Test
+    @DisplayName("답변 수정 성공 테스트")
+    void t2() {
+        // given
+        AnswerRequestDto createRequest = new AnswerRequestDto();
+        createRequest.setContent("원본 답변");
+        Integer answerId = answerCommandService.createAnswer(member1.getUsername(), question1.getId(), createRequest);
+        em.flush();
+        em.clear();
+
+        AnswerRequestDto modifyRequest = new AnswerRequestDto();
+        modifyRequest.setContent("수정된 답변");
+
+        // when
+        answerCommandService.modifyAnswer(member1.getUsername(), answerId, modifyRequest);
+        em.flush();
+        em.clear();
+
+        // then
+        Answer modifiedAnswer = answerRepository.findById(answerId).orElseThrow();
+        assertThat(modifiedAnswer.getContent()).isEqualTo("수정된 답변");
+    }
+
+    @Test
+    @DisplayName("작성자가 아닌 경우 답변 수정 실패")
+    void t3() {
+        // given
+        AnswerRequestDto createRequest = new AnswerRequestDto();
+        createRequest.setContent("원본 답변");
+        Integer answerId = answerCommandService.createAnswer(member1.getUsername(), question1.getId(), createRequest);
+        em.flush();
+        em.clear();
+
+        Member member2 = new Member("user2", "pass2", "User Two");
+        em.persist(member2);
+        em.flush();
+        em.clear();
+
+        AnswerRequestDto modifyRequest = new AnswerRequestDto();
+        modifyRequest.setContent("수정된 답변");
+
+        // then
+        assertThrows(
+                IllegalStateException.class,
+                () -> answerCommandService.modifyAnswer(member2.getUsername(), answerId, modifyRequest)
+        );
     }
 }

--- a/src/test/java/forward/javaqna/domain/answer/command/AnswerCommandServiceTest.java
+++ b/src/test/java/forward/javaqna/domain/answer/command/AnswerCommandServiceTest.java
@@ -47,10 +47,9 @@ class AnswerCommandServiceTest {
         // given
         AnswerCreateRequest request = new AnswerCreateRequest();
         request.setContent("테스트 답변입니다.");
-        request.setQuestionId(question1.getId());
 
         // when
-        int answerId = answerCommandService.createAnswer(member1.getUsername(), request);
+        Integer answerId = answerCommandService.createAnswer(member1.getUsername(), question1.getId(), request);
         em.flush();
         em.clear();
 


### PR DESCRIPTION
## 📂 작업 내용

closes #10 

- [x] 답변 수정/삭제 기능 service, repository 개발 및 테스트

## 💡 자세한 설명

- 테스트 코드에 EntityManager 추가로 영속성 컨텍스트를 지워서 DB와 동일한 상태에서 테스트
- 엔드포인트 협의 사항에 더 알맞게 AnswerCommandService 의 createAnswer 메서드 파라미터 변경
- 답변 수정 및 삭제 기능 추가
- AnswerCommandService 의 validAnswerHasMember 메서드로 수정/삭제 권한 확인
- AnswerCommandServiceTest에 각 테스트 코드 추가

## 🚩 후속 작업 (선택)

- 추후 controller, view , 입력 값 검증 개발 예정

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?