### PR TITLE
답변 등록/수정/삭제 기능 입력 값 검증, Controller/뷰 작성, 세션 인증 연동

### DIFF
--- a/src/main/java/forward/javaqna/domain/answer/command/AnswerCommandController.java
+++ b/src/main/java/forward/javaqna/domain/answer/command/AnswerCommandController.java
@@ -3,7 +3,6 @@ package forward.javaqna.domain.answer.command;
 import forward.javaqna.domain.answer.command.dto.AnswerRequestDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -17,7 +16,6 @@ import java.security.Principal;
 @Controller
 @RequestMapping("/answer")
 @RequiredArgsConstructor
-@Slf4j
 public class AnswerCommandController {
 
     private final AnswerCommandService answerCommandService;

--- a/src/main/java/forward/javaqna/domain/answer/command/AnswerCommandController.java
+++ b/src/main/java/forward/javaqna/domain/answer/command/AnswerCommandController.java
@@ -29,6 +29,12 @@ public class AnswerCommandController {
                               BindingResult bindingResult,
                               RedirectAttributes redirectAttributes) {
 
+        if (bindingResult.hasErrors()) {
+            String errorMsg = bindingResult.getAllErrors().getFirst().getDefaultMessage();
+            redirectAttributes.addFlashAttribute("errorMsg", errorMsg);
+            return "redirect:/question/find/" + questionId;
+        }
+
         answerCommandService.createAnswer(principal.getName(), questionId, answerRequestDto);
 
         return "redirect:/question/find/" + questionId;
@@ -41,6 +47,12 @@ public class AnswerCommandController {
                                @Valid @ModelAttribute("answer") AnswerRequestDto answerRequestDto,
                                BindingResult bindingResult,
                                RedirectAttributes redirectAttributes) {
+
+        if (bindingResult.hasErrors()) {
+            String errorMsg = bindingResult.getAllErrors().getFirst().getDefaultMessage();
+            redirectAttributes.addFlashAttribute("errorMsg", errorMsg);
+            return "redirect:/question/find/" + questionId;
+        }
 
         answerCommandService.modifyAnswer(principal.getName(), answerId, answerRequestDto);
 

--- a/src/main/java/forward/javaqna/domain/answer/command/AnswerCommandController.java
+++ b/src/main/java/forward/javaqna/domain/answer/command/AnswerCommandController.java
@@ -1,0 +1,59 @@
+package forward.javaqna.domain.answer.command;
+
+import forward.javaqna.domain.answer.command.dto.AnswerRequestDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.security.Principal;
+
+@Controller
+@RequestMapping("/answer")
+@RequiredArgsConstructor
+@Slf4j
+public class AnswerCommandController {
+
+    private final AnswerCommandService answerCommandService;
+
+    @PostMapping("/write/{questionId}")
+    public String writeAnswer(Principal principal,
+                              @PathVariable("questionId") Integer questionId,
+                              @Valid @ModelAttribute("answer") AnswerRequestDto answerRequestDto,
+                              BindingResult bindingResult,
+                              RedirectAttributes redirectAttributes) {
+
+        answerCommandService.createAnswer(principal.getName(), questionId, answerRequestDto);
+
+        return "redirect:/question/find/" + questionId;
+    }
+
+    @PostMapping("/modify/{questionId}/{answerId}")
+    public String modifyAnswer(Principal principal,
+                               @PathVariable("questionId") Integer questionId,
+                               @PathVariable("answerId") Integer answerId,
+                               @Valid @ModelAttribute("answer") AnswerRequestDto answerRequestDto,
+                               BindingResult bindingResult,
+                               RedirectAttributes redirectAttributes) {
+
+        answerCommandService.modifyAnswer(principal.getName(), answerId, answerRequestDto);
+
+        return "redirect:/question/find/" + questionId;
+    }
+
+    @PostMapping("/delete/{questionId}/{answerId}")
+    public String deleteAnswer(Principal principal,
+                               @PathVariable("questionId") Integer questionId,
+                               @PathVariable("answerId") Integer answerId) {
+
+        answerCommandService.deleteAnswer(principal.getName(), answerId);
+
+        return "redirect:/question/find/" + questionId;
+    }
+}

--- a/src/main/java/forward/javaqna/domain/answer/command/AnswerCommandService.java
+++ b/src/main/java/forward/javaqna/domain/answer/command/AnswerCommandService.java
@@ -33,8 +33,8 @@ public class AnswerCommandService {
     }
 
     public void modifyAnswer(String username, Integer answerId, AnswerRequestDto answerRequestDto) {
-        Member member = getMember(username);
         Answer answer = getAnswer(answerId);
+        Member member = getMember(username);
         AnswerPolicy.checkAuthor(answer, member);
 
         String newContent = answerRequestDto.getContent();
@@ -42,8 +42,8 @@ public class AnswerCommandService {
     }
 
     public void deleteAnswer(String username, Integer answerId) {
-        Member member = getMember(username);
         Answer answer = getAnswer(answerId);
+        Member member = getMember(username);
         AnswerPolicy.checkAuthor(answer, member);
 
         answerRepository.delete(answer);
@@ -60,7 +60,7 @@ public class AnswerCommandService {
     }
 
     private Answer getAnswer(Integer answerId) {
-        return answerRepository.findById(answerId)
+        return answerRepository.findByIdEager(answerId)
                 .orElseThrow(() -> new EntityNotFoundException("답변이 존재하지 않습니다."));
     }
 }

--- a/src/main/java/forward/javaqna/domain/answer/command/dto/AnswerRequestDto.java
+++ b/src/main/java/forward/javaqna/domain/answer/command/dto/AnswerRequestDto.java
@@ -3,11 +3,15 @@ package forward.javaqna.domain.answer.command.dto;
 import forward.javaqna.domain.answer.core.Answer;
 import forward.javaqna.domain.member.core.Member;
 import forward.javaqna.domain.question.core.Question;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
 public class AnswerRequestDto {
 
+    @Size(min = 2, max = 1000, message = "2 ~ 1000자 이내로 입력해주세요.")
+    @NotBlank(message = "내용을 입력해주세요.")
     private String content;
 
     public Answer toEntity(Member member, Question question) {

--- a/src/main/java/forward/javaqna/domain/answer/core/AnswerRepository.java
+++ b/src/main/java/forward/javaqna/domain/answer/core/AnswerRepository.java
@@ -1,8 +1,15 @@
 package forward.javaqna.domain.answer.core;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface AnswerRepository extends JpaRepository<Answer, Integer> {
 
     void deleteByQuestion_Id(Integer questionId);
+
+    @Query("select a from Answer a join fetch a.member where a.id = :id")
+    Optional<Answer> findByIdEager(@Param("id") Integer id);
 }

--- a/src/main/resources/templates/question/find.html
+++ b/src/main/resources/templates/question/find.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" xmlns:sec="http://www.w3.org/1999/xhtml">
 <head>
     <meta charset="UTF-8">
     <title>Title</title>
@@ -46,7 +46,7 @@
                     <p class="text-gray-700 leading-relaxed" th:text="${answer.content}"></p>
 
                     <!-- 버튼 영역 -->
-                    <div class="flex gap-2 mt-2">
+                    <div class="flex gap-2 mt-2" sec:authorize="isAuthenticated()" th:if="${#authentication.name == answer.member.username}">
                         <!-- 수정 버튼 -->
                         <button type="button"
                                 th:onclick="'toggleEditForm(\'editForm__' + ${answer.id} + '\')'"
@@ -92,7 +92,7 @@
     </div>
 
     <!-- Answer 작성 폼 추가 -->
-    <div class="mt-6">
+    <div class="mt-6" sec:authorize="isAuthenticated()">
         <span class="block text-sm text-gray-500 mb-2">Write an Answer</span>
 
         <form th:action="@{|/answer/write/${question.id}|}" method="POST" class="space-y-4">

--- a/src/main/resources/templates/question/find.html
+++ b/src/main/resources/templates/question/find.html
@@ -36,14 +36,57 @@
 
             <div class="space-y-4">
                 <div th:each="answer : ${question.answerList}"
-                     class="p-4 bg-gray-50 border border-gray-200 rounded-xl shadow-sm hover:shadow-md transition">
+                     class="p-4 bg-gray-50 border border-gray-200 rounded-xl shadow-sm hover:shadow-md transition mb-4">
+
+                    <!-- 기존 답변 표시 영역 -->
                     <div class="flex justify-between items-center mb-2">
                         <span class="text-xs text-gray-400">#<span th:text="${answer.id}"></span></span>
-                        <span class="text-sm font-medium text-blue-600"
-                              th:text="${answer.member.nickname}">작성자</span>
+                        <span class="text-sm font-medium text-blue-600" th:text="${answer.member.nickname}">작성자</span>
                     </div>
                     <p class="text-gray-700 leading-relaxed" th:text="${answer.content}"></p>
+
+                    <!-- 버튼 영역 -->
+                    <div class="flex gap-2 mt-2">
+                        <!-- 수정 버튼 -->
+                        <button type="button"
+                                th:onclick="'toggleEditForm(\'editForm__' + ${answer.id} + '\')'"
+                                class="text-sm text-yellow-600 hover:underline">
+                            수정
+                        </button>
+
+                        <!-- 삭제 폼 -->
+                        <form th:action="@{|/answer/delete/${question.id}/${answer.id}|}" method="post"
+                              th:object="${answer}" onsubmit="return confirm('정말 삭제하시겠습니까?');">
+                            <button type="submit" class="text-sm text-red-600 hover:underline">삭제</button>
+                        </form>
+                    </div>
+
+                    <!-- 수정 폼 -->
+                    <form th:id="'editForm__' + ${answer.id}" th:action="@{|/answer/modify/${question.id}/${answer.id}|}"
+                          method="post" class="mt-2 hidden">
+                        <textarea name="content" class="w-full p-2 border rounded" th:text="${answer.content}"></textarea>
+                        <div class="flex justify-end gap-2 mt-1">
+                            <button type="submit" class="text-sm text-white bg-blue-500 px-3 py-1 rounded hover:bg-blue-600">
+                                저장
+                            </button>
+                            <button type="button" class="text-sm text-gray-600 px-3 py-1 rounded border hover:bg-gray-100"
+                                    th:onclick="'toggleEditForm(\'editForm__' + ${answer.id} + '\')'">
+                                취소
+                            </button>
+                        </div>
+                    </form>
                 </div>
+
+                <script>
+                    function toggleEditForm(formId) {
+                        const form = document.getElementById(formId);
+                        if (form.classList.contains('hidden')) {
+                            form.classList.remove('hidden');
+                        } else {
+                            form.classList.add('hidden');
+                        }
+                    }
+                </script>
             </div>
         </div>
     </div>
@@ -52,7 +95,7 @@
     <div class="mt-6">
         <span class="block text-sm text-gray-500 mb-2">Write an Answer</span>
 
-        <form action="#" method="get" class="space-y-4">
+        <form th:action="@{|/answer/write/${question.id}|}" method="POST" class="space-y-4">
             <div>
             <textarea name="content" rows="4" required
                       class="w-full px-4 py-2 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-400 resize-none"

--- a/src/main/resources/templates/question/find.html
+++ b/src/main/resources/templates/question/find.html
@@ -118,5 +118,11 @@
         </a>
     </div>
 </div>
+
+<!-- alert 스크립트 -->
+<script th:if="${errorMsg != null}">
+    alert('[[${#strings.escapeJavaScript(errorMsg)}]]');
+</script>
+
 </body>
 </html>


### PR DESCRIPTION
## 📂 작업 내용

closes #15 

- [x] 답변 등록/수정/삭제 기능 완료

## 💡 자세한 설명

- AnswerRepository에 findByIdEager 추가로 기존 최대 2회 쿼리 -> 최대 1회 쿼리 최적화
- Controller 작성 및 view, 기존에 비즈니스 로직과 연동
- 등록 폼과 수정/삭제 버튼을 권한에 따라 UI 처리
- 입력 값 검증추가 (입력 값 검증 실패 시, RedirectAttributes에 에러 메시지 담아 게시글 상세 페이지로 redirect)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [ ] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?